### PR TITLE
heim-memory: expose "dirty" memory value

### DIFF
--- a/heim-memory/src/os/linux.rs
+++ b/heim-memory/src/os/linux.rs
@@ -31,6 +31,9 @@ pub trait MemoryExt {
     ///
     /// This is memory that has not been recently used and can be reclaimed for other purposes.
     fn inactive(&self) -> Information;
+
+    /// Memory which is waiting to get written back to the disk.
+    fn dirty(&self) -> Information;
 }
 
 #[cfg(target_os = "linux")]
@@ -67,5 +70,9 @@ impl MemoryExt for Memory {
 
     fn inactive(&self) -> Information {
         self.as_ref().inactive()
+    }
+
+    fn dirty(&self) -> Information {
+        self.as_ref().dirty()
     }
 }

--- a/heim-memory/src/sys/linux/memory.rs
+++ b/heim-memory/src/sys/linux/memory.rs
@@ -15,6 +15,7 @@ pub struct Memory {
     active: Information,    // Active
     inactive: Information,  // Inactive
     shared: Information,    // Shmem
+    dirty: Information,     // Dirty
 }
 
 impl Memory {
@@ -42,6 +43,10 @@ impl Memory {
     pub fn shared(&self) -> Information {
         self.shared
     }
+
+    pub fn dirty(&self) -> Information {
+        self.dirty
+    }
 }
 
 impl FromStr for Memory {
@@ -56,7 +61,7 @@ impl FromStr for Memory {
             // we do not need that key at all
             let first_bytes = &line.as_bytes()[..2];
             match first_bytes {
-                b"Me" | b"Ac" | b"In" | b"Bu" | b"Ca" | b"Sh" => {}
+                b"Me" | b"Ac" | b"In" | b"Bu" | b"Ca" | b"Sh" | b"Di" => {}
                 _ => continue,
             };
 
@@ -70,6 +75,7 @@ impl FromStr for Memory {
                 Some("Active") => &mut memory.active,
                 Some("Inactive") => &mut memory.inactive,
                 Some("Shmem") => &mut memory.shared,
+                Some("Dirty") => &mut memory.dirty,
                 _ => continue,
             };
 

--- a/heim-memory/tests/smoke.rs
+++ b/heim-memory/tests/smoke.rs
@@ -22,6 +22,7 @@ async fn smoke_memory() {
         let _ = mem.shared();
         let _ = mem.active();
         let _ = mem.inactive();
+        let _ = mem.dirty();
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
exposes the /proc/meminfo's Dirty field