### PR TITLE
Fix mismatched type on s390x

### DIFF
--- a/heim-host/src/os/linux.rs
+++ b/heim-host/src/os/linux.rs
@@ -5,8 +5,8 @@ use std::net::IpAddr;
 use crate::Pid;
 
 cfg_if::cfg_if! {
-    // aarch64-unknown-linux-gnu has different type
-    if #[cfg(all(target_arch = "aarch64", not(target_family = "musl")))] {
+    // aarch64-unknown-linux-gnu and s390x-unknown-linux-gnu has different type
+    if #[cfg(any(target_arch = "s390x",all(target_arch = "aarch64", not(target_family = "musl"))))] {
         /// User session ID.
         pub type SessionId = i64;
     } else {


### PR DESCRIPTION
While compiling on Linux s390x, we were getting the error 

```
error[E0308]: mismatched types
  --> heim-host/src/sys/linux/users/other.rs:80:25
   |
80 |             session_id: entry.ut_session,
   |                         ^^^^^^^^^^^^^^^^ expected `i32`, found
`i64`

For more information about this error, try `rustc --explain E0308`.
```
This PR fixes the compilation error on heim-host